### PR TITLE
feat-7

### DIFF
--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -2,7 +2,7 @@ import React, {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 
-import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { useSelector } from 'react-redux';
 import { getType } from 'typesafe-actions';
 
@@ -13,7 +13,11 @@ import { RootState } from 'store/types';
 
 const LINE_COUNT = 2;
 
-const useStyles = makeStyles((theme) => createStyles({
+type Props = {
+  draggable: string;
+};
+
+const useStyles = makeStyles<Theme, Props>((theme) => createStyles({
   main: {
     display: 'inline-flex',
     flexDirection: 'column',

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -27,8 +27,9 @@ const useStyles = makeStyles<Theme, Props>((theme) => createStyles({
     alignItems: 'center',
     textAlign: 'center',
     whiteSpace: 'nowrap',
-    transition: 'width .3s, height .3s',
+    transition: 'width .3s, height .3s opacity .3s',
     overflow: 'hidden',
+    '-webkit-app-region': ({ draggable }) => (draggable === 'ON' ? 'drag' : 'no-drag'),
   },
   wrap: {
     padding: `${theme.spacing(1)}px ${theme.spacing(4)}px`,
@@ -53,23 +54,27 @@ const selector = ({
     currentOffset,
     globalOffset,
   },
+  layout: { draggable },
 }: RootState) => ({
   music: (lastSelected !== undefined ? list[lastSelected] : undefined),
   isPlaying,
   currentOffset,
   globalOffset,
-});
+  draggable,
+}
+);
 
 const Main: React.FC = () => {
   const domRef = useRef<HTMLDivElement | null>(null);
-  const classes = useStyles();
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const [position, setPosition] = useState(0);
   const [time, setTime] = useState(0);
   const [index, setIndex] = useState(0);
-  const { isPlaying, music, currentOffset, globalOffset } = useSelector(selector);
+  const { isPlaying, music, currentOffset, globalOffset, draggable } = useSelector(selector);
+  const classes = useStyles({ draggable });
   const lyrics = useMemo(() => music?.lyric, [music?.lyric]);
+  const [opacity, setOpacity] = useState(1);
 
   useEffect(() => {
     let timerId: number | null = null;
@@ -132,8 +137,12 @@ const Main: React.FC = () => {
 
   return (
     <>
-      <Draggable />
-      <div className={classes.main} style={{ width, height }}>
+      <div
+        className={classes.main}
+        style={{ width, height, opacity }}
+        onMouseEnter={() => (draggable === 'OFF' ? setOpacity(0) : null)}
+        onMouseLeave={() => (draggable === 'OFF' ? setOpacity(1) : null)}
+      >
         <div className={classes.wrap} ref={domRef}>
           {selectedLyrics.map(({
             text,

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -6,7 +6,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { useSelector } from 'react-redux';
 import { getType } from 'typesafe-actions';
 
-import Draggable from 'components/Draggable';
+// import Draggable from 'components/Draggable';
 import musicActions from 'store/music/actions';
 import { Music } from 'store/music/types';
 import { RootState } from 'store/types';

--- a/src/pages/Preference/Settings/index.tsx
+++ b/src/pages/Preference/Settings/index.tsx
@@ -1,30 +1,58 @@
 import React, { useCallback, useState } from 'react';
 
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import TextField from '@material-ui/core/TextField';
 import { useDispatch } from 'react-redux';
 
+import layoutAction from 'store/layout/actions';
 import actions from 'store/music/actions';
 
 const Settings: React.FC = () => {
   const dispatch = useDispatch();
   const [offset, setOffset] = useState(-0.5);
+  const [draggable, setDraggable] = useState('ON');
 
   const handleOnChange = useCallback((e) => {
     dispatch(actions.setGlobalOffset(e.target.value));
     setOffset(() => Number(e.target.value));
   }, [dispatch]);
+
+  const handleOnChangeDraggable = useCallback((e) => {
+    dispatch(layoutAction.setDraggable(e.target.value));
+    setDraggable(() => String(e.target.value));
+  }, [dispatch]);
+
   return (
-    <TextField
-      type='number'
-      value={offset}
-      label='Offset'
-      variant='outlined'
-      inputProps={{
-        maxLength: 13,
-        step: '0.1',
-      }}
-      onChange={handleOnChange}
-    />
+    <>
+      <TextField
+        type='number'
+        value={offset}
+        label='Offset'
+        variant='outlined'
+        inputProps={{
+          maxLength: 13,
+          step: '0.1',
+        }}
+        onChange={handleOnChange}
+      />
+      <InputLabel id='demo-simple-select-autowidth-label'>
+        Draggable
+      </InputLabel>
+      <Select
+        labelId='demo-simple-select-autowidth-label'
+        id='demo-simple-select-autowidth'
+        value={draggable}
+        onChange={handleOnChangeDraggable}
+        autoWidth
+        label='Draggable'
+        defaultValue={draggable}
+      >
+        <MenuItem value='ON'>ON</MenuItem>
+        <MenuItem value='OFF'>OFF</MenuItem>
+      </Select>
+    </>
   );
 };
 

--- a/src/store/layout/actions.ts
+++ b/src/store/layout/actions.ts
@@ -4,5 +4,6 @@ import { Actions, LayoutState } from './types';
 
 const setPalette = createAction(Actions.SET_PALETTE)<LayoutState['palette']>();
 const closePreference = createAction(Actions.CLOSE_PREFERENCE)();
+const setDraggable = createAction(Actions.SET_DRAGGABLE)<LayoutState['draggable']>();
 
-export default { setPalette, closePreference };
+export default { setPalette, closePreference, setDraggable };

--- a/src/store/layout/reducer.ts
+++ b/src/store/layout/reducer.ts
@@ -13,6 +13,10 @@ const layoutReducer = createReducer<LayoutState>(initialState)
   .handleAction(layoutActions.setPalette, (state, action) => ({
     ...state,
     palette: action.payload,
+  }))
+  .handleAction(layoutActions.setDraggable, (state, action) => ({
+    ...state,
+    draggable: action.payload,
   }));
 
 export default persistReducer(persistConfig, layoutReducer);


### PR DESCRIPTION
1. preference-setting에서 Draggable(가상 정보 창의 드래그 가능 여부 상태)를 설정 할 수 있도록 하는 기능 추가.

2. Draggable이 가능한 상태(Draggable이 "ON" - 기본값)인 경우
> '-webkit-app-region'값을 drag의 값으로해 drag가 가능하게 만들었습니다.

3. Draggable이 불가능한 상태(Draggable이 "OFF")로 변경된 경우
> '-webkit-app-region' 을  'no-drag'로 변경해 drag가 불가능하게 만들었습니다.
> 드래그가 불가능한 경우에는 가사 정보가 사용자가 기존에 보고있던 컨텐츠를 가릴 수 있습니다. 이를 방지하기 위해 가사 정보가 나오는 곳에 hover를 하면 opacity를 0으로 transition해 가사 정보가 다른 컨텐츠를 가리지 않도록 하는 기능을 추가했습니다.